### PR TITLE
Update tsconfig.json and webpack.js to work properly with Windows

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -29,8 +29,8 @@
       "sinon-chai"
     ],
     "typeRoots": [
-      "node_modules/@types",
-      "node_modules"
+      "../node_modules/@types",
+      "../node_modules"
     ]
   },
   "exclude": [

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -9,10 +9,10 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const tsconfig = require('./tsconfig');
 
 const path = {
-  root: process.env.ROOT_PATH,
-  source: process.env.SOURCE_PATH,
-  target: process.env.TARGET_PATH,
-  test: process.env.TEST_PATH
+  root: resolve(process.env.ROOT_PATH),
+  source: resolve(process.env.SOURCE_PATH),
+  target: resolve(process.env.TARGET_PATH),
+  test: resolve(process.env.TEST_PATH)
 };
 
 const pattern = {


### PR DESCRIPTION
Added resolving for the env paths in webpack.js, otherwise it doesn't consider it an absolute path.
Fixed typeroots to point at the correct place.